### PR TITLE
add support for specifying js runtime (node, dino, etc...) instead of the current one

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {AsyncReturnType} from 'type-fest';
+import { AsyncReturnType } from 'type-fest';
 
 // TODO: Move these to https://github.com/sindresorhus/type-fest
 type AsyncFunction = (...args: any[]) => Promise<unknown>;
@@ -10,6 +10,8 @@ Returns a wrapped version of the given async function which executes synchronous
 The given function is executed in a subprocess, so you cannot use any variables/imports from outside the scope of the function. You can pass in arguments to the function. To import dependencies, use either `require(…)` or `await import(…)` in the function body.
 
 It uses the V8 serialization API transfer arguments, return values, errors between the subprocess and the current process. It supports most values, but not functions and symbols.
+
+The optional execPath argument is used to run a different javascript runtime. This is useful for running a node subprocess from an electron main process.
 
 @example
 ```
@@ -27,6 +29,6 @@ console.log(fn(2));
 //=> 4
 ```
 */
-declare function makeSynchronous<T extends AsyncFunction>(asyncFunction: T): ReplaceReturnType<T, AsyncReturnType<T>>;
+declare function makeSynchronous<T extends AsyncFunction>(asyncFunction: T, execPath?: string): ReplaceReturnType<T, AsyncReturnType<T>>;
 
 export = makeSynchronous;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const Subsume = require('subsume');
 
 const HUNDRED_MEGABYTES = 1000 * 1000 * 100;
 
-module.exports = function_ => {
+module.exports = (function_, execPath = process.execPath) => {
 	return (...arguments_) => {
 		const serializedArguments = v8.serialize(arguments_).toString('hex');
 		const subsume = new Subsume();
@@ -32,7 +32,7 @@ module.exports = function_ => {
 			})();
 		`;
 
-		const {error: subprocessError, stdout, stderr} = childProcess.spawnSync(process.execPath, ['-'], {
+		const { error: subprocessError, stdout, stderr } = childProcess.spawnSync(execPath, ['-'], {
 			input,
 			encoding: 'utf8',
 			maxBuffer: HUNDRED_MEGABYTES
@@ -42,7 +42,7 @@ module.exports = function_ => {
 			throw subprocessError;
 		}
 
-		const {data, rest} = subsume.parse(stdout);
+		const { data, rest } = subsume.parse(stdout);
 
 		process.stdout.write(rest);
 		process.stderr.write(stderr);
@@ -51,7 +51,7 @@ module.exports = function_ => {
 			return;
 		}
 
-		const {error, result} = v8.deserialize(Buffer.from(data, 'hex'));
+		const { error, result } = v8.deserialize(Buffer.from(data, 'hex'));
 
 		if (error) {
 			throw error;


### PR DESCRIPTION
This is necessary for using this in electron, since this just fails if you run in from the main process of electron.

It opens the default electron window and doesn't do the computation at all.