### PR TITLE
fix: make .unref() optional for Deno compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ function makeSynchronous(function_) {
 	function createWorker() {
 		if (!cache) {
 			const {port1: mainThreadPort, port2: workerPort} = new MessageChannel();
-			mainThreadPort.unref();
-			workerPort.unref();
+			mainThreadPort.unref?.();
+			workerPort.unref?.();
 
 			const code = `
 				import setupWorker from ${JSON.stringify(import.meta.url)};
@@ -46,7 +46,7 @@ function makeSynchronous(function_) {
 				},
 				transferList: [workerPort],
 			});
-			worker.unref();
+			worker.unref?.();
 
 			cache = {worker, mainThreadPort};
 		}


### PR DESCRIPTION
**Description of Change**

Fixes an issue where running the worker code in Deno caused a runtime error: `unref is not defined`. This was due to Node.js-specific `.unref()` calls on `Worker` and `MessagePort` objects. Using optional chaining (`.unref?.()`) ensures that the code runs in Deno without affecting Node.js behavior.

**Checklist**

* [x] `npm test` passes

**Release Notes**

Notes: Fixed a runtime error in Deno caused by `.unref()` calls. This makes workers compatible across Node.js and Deno.